### PR TITLE
Fix LocationListenerImpl instantiation

### DIFF
--- a/source/nativescript-geolocation.ios.ts
+++ b/source/nativescript-geolocation.ios.ts
@@ -9,6 +9,7 @@ import common = require("./nativescript-geolocation-common");
 global.moduleMerge(common, exports);
 
 var locationManagers = {};
+var locationListeners = {};
 var watchId = 0;
 var minRangeUpdate = 0; // 0 meters
 var defaultGetLocationTimeout = 5 * 60 * 1000; // 5 minutes
@@ -119,12 +120,14 @@ export class LocationMonitor implements LocationMonitorDef {
             locationManagers[iosLocManagerId].stopUpdatingLocation();
             locationManagers[iosLocManagerId].delegate = null;
             delete locationManagers[iosLocManagerId];
+            delete locationListeners[iosLocManagerId];
         }
     }
 
     static startLocationMonitoring(options, locListener) {
         var iosLocManager = LocationMonitor.createiOSLocationManager(locListener, options);
         locationManagers[locListener.id] = iosLocManager;
+        locationListeners[locListener.id] = locListener;
         iosLocManager.startUpdatingLocation();
     }
 
@@ -140,6 +143,7 @@ export class LocationMonitor implements LocationMonitorDef {
         iosLocManager.desiredAccuracy = options ? options.desiredAccuracy : enums.Accuracy.high;
         iosLocManager.distanceFilter = options ? options.updateDistance : minRangeUpdate;
         locationManagers[locListener.id] = iosLocManager;
+        locationListeners[locListener.id] = locListener;
         return iosLocManager;
     }
 }

--- a/source/nativescript-geolocation.ios.ts
+++ b/source/nativescript-geolocation.ios.ts
@@ -105,7 +105,7 @@ export class LocationMonitor implements LocationMonitorDef {
             return locationFromCLLocation(iosLocation);
         }
 
-        var locListener = new LocationListenerImpl();
+        var locListener = LocationListenerImpl.new();
         locListener.initWithLocationErrorOptions(null, null, null);
         iosLocation = LocationMonitor.createiOSLocationManager(locListener, null).location;
         if (iosLocation) {
@@ -129,7 +129,7 @@ export class LocationMonitor implements LocationMonitorDef {
     }
 
     static createListenerWithCallbackAndOptions(successCallback, options) {
-        var locListener = new LocationListenerImpl();
+        var locListener = LocationListenerImpl.new();
         locListener.initWithLocationErrorOptions(successCallback, null, options);
         return locListener;
     }
@@ -178,7 +178,7 @@ export function enableLocationRequest(always?: boolean) {
 }
 
 export function watchLocation(successCallback, errorCallback, options) {
-    var locListener = new LocationListenerImpl();
+    var locListener = LocationListenerImpl.new();
     locListener.initWithLocationErrorOptions(successCallback, errorCallback, options);
     try {
         var iosLocManager = LocationMonitor.createiOSLocationManager(locListener, options);


### PR DESCRIPTION
The LocationListenerImpl objects were not being created with ids (the LocationListenerImpl.new static method was never being called), and were also not being retained, meaning they could have been garbage collected at any moment. This PR fixes these problems.  