### PR TITLE
Adjusting to the real solution for the webpack problem.

### DIFF
--- a/source/tsconfig.json
+++ b/source/tsconfig.json
@@ -8,7 +8,7 @@
         "sourceMap": false,
         "declaration": false,
         "noLib": false,
-        "noImplicitUseStrict": true,
+        "noEmitHelpers": true,
         "experimentalDecorators": true
     },
     "filesGlob": [


### PR DESCRIPTION
Hi @hdeshev, I confirmed that this is the real solution for the webpack problem and not the previous. The previous does avoid the initial error but it fails eventually when a method is call (it says something like "Error: This value is not a native object" when executing an apply inside nativescript-zone.js, commenting in case useful for some other problem).