### PR TITLE
iOS: Adding options to use in long-running background tasks

### DIFF
--- a/source/location-monitor.d.ts
+++ b/source/location-monitor.d.ts
@@ -28,6 +28,21 @@ export interface Options {
     * how long to wait for a location in ms.
     */
     timeout?: number;
+
+    /**
+     * A Boolean value which has to be set to true on iOS versions > 9.0 to allow the application to receive location updates in 
+     * background (e.g. in combination with the UIBackgroundModes key 'location' in the Info.plist). The value is ignored on Android.
+     * @see {@link https://developer.apple.com/reference/corelocation/cllocationmanager/1620568-allowsbackgroundlocationupdates|allowsBackgroundLocationUpdates} 
+     */
+    iosAllowsBackgroundLocationUpdates?: boolean;
+
+    /**
+     * A Boolean value which has to be set to false on iOS to deactivate the automatic pause of location updates. The location manager might pause 
+     * location updates for a period of time to improve battery life. This behavior may stop a long-running background task. Set this flag to false
+     * to prevent this behavior. The value is ignored on Android.
+     * @see {@link https://developer.apple.com/reference/corelocation/cllocationmanager/1620553-pauseslocationupdatesautomatical|pausesLocationUpdatesAutomatically}
+     */
+    iosPausesLocationUpdatesAutomatically?: boolean;
 }
 
 declare type successCallbackType = (location: Location) => void;

--- a/source/nativescript-geolocation.ios.ts
+++ b/source/nativescript-geolocation.ios.ts
@@ -324,10 +324,10 @@ export class LocationMonitor implements LocationMonitorDef {
         locationManagers[locListener.id] = iosLocManager;
         locationListeners[locListener.id] = locListener;
         if (parseInt(Platform.device.osVersion.split(".")[0]) >= 9) {
-            iosLocManager.allowsBackgroundLocationUpdates = options.iosAllowsBackgroundLocationUpdates != null ?
+            iosLocManager.allowsBackgroundLocationUpdates = options && options.iosAllowsBackgroundLocationUpdates != null ?
                 options.iosAllowsBackgroundLocationUpdates : false;
         }
-        iosLocManager.pausesLocationUpdatesAutomatically = options.iosPausesLocationUpdatesAutomatically != null ?
+        iosLocManager.pausesLocationUpdatesAutomatically = options && options.iosPausesLocationUpdatesAutomatically != null ?
             options.iosPausesLocationUpdatesAutomatically : true;
         return iosLocManager;
     }

--- a/source/nativescript-geolocation.ios.ts
+++ b/source/nativescript-geolocation.ios.ts
@@ -257,7 +257,7 @@ export function enableLocationRequest(always?: boolean): Promise<void> {
 
 export function isEnabled(): boolean {
     if (CLLocationManager.locationServicesEnabled()) {
-        // CLAuthorizationStatus.kCLAuthorizationStatusAuthorizedWhenInUse and 
+        // CLAuthorizationStatus.kCLAuthorizationStatusAuthorizedWhenInUse and
         // CLAuthorizationStatus.kCLAuthorizationStatusAuthorizedAlways are options that are available in iOS 8.0+
         // while CLAuthorizationStatus.kCLAuthorizationStatusAuthorized is here to support iOS 8.0-.
         const AUTORIZED_WHEN_IN_USE = CLAuthorizationStatus.kCLAuthorizationStatusAuthorizedWhenInUse;
@@ -324,10 +324,12 @@ export class LocationMonitor implements LocationMonitorDef {
         locationManagers[locListener.id] = iosLocManager;
         locationListeners[locListener.id] = locListener;
         if (parseInt(Platform.device.osVersion.split(".")[0]) >= 9) {
-            iosLocManager.allowsBackgroundLocationUpdates = options && options.iosAllowsBackgroundLocationUpdates != null ?
+            iosLocManager.allowsBackgroundLocationUpdates =
+                options && options.iosAllowsBackgroundLocationUpdates != null ?
                 options.iosAllowsBackgroundLocationUpdates : false;
         }
-        iosLocManager.pausesLocationUpdatesAutomatically = options && options.iosPausesLocationUpdatesAutomatically != null ?
+        iosLocManager.pausesLocationUpdatesAutomatically =
+            options && options.iosPausesLocationUpdatesAutomatically != null ?
             options.iosPausesLocationUpdatesAutomatically : true;
         return iosLocManager;
     }

--- a/source/nativescript-geolocation.ios.ts
+++ b/source/nativescript-geolocation.ios.ts
@@ -12,6 +12,7 @@ import {
     successCallbackType,
     errorCallbackType
 } from "./location-monitor";
+import * as Platform from "platform";
 
 const locationManagers = {};
 const locationListeners = {};
@@ -322,6 +323,12 @@ export class LocationMonitor implements LocationMonitorDef {
         iosLocManager.distanceFilter = options ? options.updateDistance : minRangeUpdate;
         locationManagers[locListener.id] = iosLocManager;
         locationListeners[locListener.id] = locListener;
+        if (parseInt(Platform.device.osVersion.split(".")[0]) >= 9) {
+            iosLocManager.allowsBackgroundLocationUpdates = options.iosAllowsBackgroundLocationUpdates != null ?
+                options.iosAllowsBackgroundLocationUpdates : false;
+        }
+        iosLocManager.pausesLocationUpdatesAutomatically = options.iosPausesLocationUpdatesAutomatically != null ?
+            options.iosPausesLocationUpdatesAutomatically : true;
         return iosLocManager;
     }
 }


### PR DESCRIPTION
Hi,

i'm currently dealing with long-running background tasks on iOS. On iOS versions > 9.0 one can't receive location updates in background in combination with the `UIBackgroundModes` key `location` in the Info.plist, because the `allowsBackgroundLocationUpdates` flag has to be set to true on the used location manager instance (https://developer.apple.com/reference/corelocation/cllocationmanager/1620568-allowsbackgroundlocationupdates). Receiving location updates in background only works by using `beginBackgroundTaskWithExpirationHandler`, which suspends the background task after about 3 minutes,

Furthermore, long-running background tasks which consume location updates can be suspended if the location updates are paused by the location manager. This behavior can be deactivated by setting the `pausesLocationUpdatesAutomatically` flag of the location manager instance to false (https://developer.apple.com/reference/corelocation/cllocationmanager/1620553-pauseslocationupdatesautomatical).

It would be nice to have control over these location manager flags to use the plugin in long-running background tasks. Would it be possible to integrate these flags as options?

(tested on iOS 10.2.1)