### PR TITLE
fix ios accuracy

### DIFF
--- a/demo/app/app-root.xml
+++ b/demo/app/app-root.xml
@@ -1,0 +1,2 @@
+<Frame defaultPage="main-page">
+</Frame>

--- a/demo/app/app.ts
+++ b/demo/app/app.ts
@@ -1,2 +1,2 @@
 ﻿import * as application from 'tns-core-modules/application';
-application.start({ moduleName: "main-page" });
+application.run({ moduleName: "app-root" });

--- a/demo/app/tests/mock-ios.js
+++ b/demo/app/tests/mock-ios.js
@@ -19,6 +19,14 @@ var MockLocationManager = (function () {
             return _this._requestSingleUpdate(_this.delegate, _this);
         }, 500);
     };
+    MockLocationManager.prototype.requestLocation = function () {
+        var _this = this;
+        this.removeUpdates(null);
+        MockLocationManager.intervalId = setTimeout(function () {
+            // this.delegate is the location listener
+            return _this._requestSingleUpdate(_this.delegate, _this);
+        }, 500);
+    };
     MockLocationManager.prototype._requestSingleUpdate = function (locListener, instance) {
         var newLocation = {
             coordinate: {

--- a/src/geolocation.ios.ts
+++ b/src/geolocation.ios.ts
@@ -185,18 +185,17 @@ export function getCurrentLocation(options: Options): Promise<Location> {
                             return;
                         }
 
-                        if (options.desiredAccuracy !== Accuracy.any && !initLocation) {                            
+                        if (options.desiredAccuracy !== Accuracy.any && !initLocation) {
                             // regardless of desired accuracy ios returns first location as quick as possible even if not as accurate as requested
                             initLocation = location;
                             return;
-                            
                         }
                     }
 
                     stopTimerAndMonitor(locListener.id);
                     resolve(location);
                 };
-                
+
                 locListener = LocationListenerImpl.initWithLocationError(successCallback, reject);
                 try {
                     if (getVersionMaj() >= 9) {
@@ -214,7 +213,7 @@ export function getCurrentLocation(options: Options): Promise<Location> {
                         LocationMonitor.stopLocationMonitoring(locListener.id);
                         reject(new Error("Timeout while searching for location!"));
                     }, options.timeout || defaultGetLocationTimeout);
-                }         
+                }
             }
         }, reject);
     });


### PR DESCRIPTION
When requesting a high accuracy for ios we often receive a not so accurate location due to the fact that when starting update location ios will send a first location as quick as possible although not with the desired accuracy so desiredAccuracy was basically ignored on ios. Since from version 9+ the requestLocation API was introduced thought to use that as well, still if timeout option is specified the good old timer must be used.