### PR TITLE
Revert "fix ios accuracy"

### DIFF
--- a/demo/app/tests/mock-ios.js
+++ b/demo/app/tests/mock-ios.js
@@ -19,14 +19,6 @@ var MockLocationManager = (function () {
             return _this._requestSingleUpdate(_this.delegate, _this);
         }, 500);
     };
-    MockLocationManager.prototype.requestLocation = function () {
-        var _this = this;
-        this.removeUpdates(null);
-        MockLocationManager.intervalId = setTimeout(function () {
-            // this.delegate is the location listener
-            return _this._requestSingleUpdate(_this.delegate, _this);
-        }, 500);
-    };
     MockLocationManager.prototype._requestSingleUpdate = function (locListener, instance) {
         var newLocation = {
             coordinate: {


### PR DESCRIPTION
Reverts NativeScript/nativescript-geolocation#200
@akera-io 
We tested the branch using *requestLocation*  and the implementation before the merge and found that both provide similar location. The difference is that now it always takes 10sec to return a location no matter the timeout.

@akera-io What is your observation after the fix? How do you measure the improvement while using the fix? We don't see any improvement on our side.