### PR TITLE
Update the plugin for Gradle 7.5

### DIFF
--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -12,5 +12,5 @@ android {
 
 dependencies {
 	def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : "11.4.0"
-	compile "com.google.android.gms:play-services-location:$googlePlayServicesVersion"
+	implementation "com.google.android.gms:play-services-location:$googlePlayServicesVersion"
 }


### PR DESCRIPTION
Since most recent versions use Gradle 7.5, compile keyword has been deprecated, so instead it uses implementation.