### PR TITLE
Update commit dependency with implementation dependency.

### DIFF
--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -12,5 +12,5 @@ android {
 
 dependencies {
 	def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : "11.4.0"
-	compile "com.google.android.gms:play-services-location:$googlePlayServicesVersion"
+	implementation "com.google.android.gms:play-services-location:$googlePlayServicesVersion"
 }


### PR DESCRIPTION

The java docs are saying that

`compile` dependency is deprecated in gradle 7.0 and It was supressed by `implementation` dependency.

If the `compile` dependency is used the it is arising an error in nativescript-angular project while building android application using `ns run android`.
